### PR TITLE
Fixed build script to include the right folder into the jar

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -14,7 +14,7 @@
 
   <target name="dist" depends="compile" description="generate jar file" >
     <mkdir dir="${dist}"/>
-    <jar jarfile="${dist}/${ant.project.name}.jar" basedir="${src}" excludes="*.sh"/>
+    <jar jarfile="${dist}/${ant.project.name}.jar" basedir="${build}" excludes="*.sh"/>
   </target>
 
   <target name="clean" description="clean up" >


### PR DESCRIPTION
Source-files were included in the JAR instead of the Class-files. 
